### PR TITLE
new tileset, status tooltip fix, and get status logic

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -35,7 +35,7 @@ const req0 = http.request(options, (res0) =>
     })
   }).on("error", (e) => {
     const err = "Got error:"+e.message;
-    res0.send(err);
+    console.error(err);
 });
 
 req0.write("body");
@@ -63,7 +63,7 @@ exports.getStatus = functions.https.onRequest(async (req, res) => {
     res.status(204).send('');
   } else {
     // write to firebase realtime
-    const writeResult = await admin.firestore().collection("status").doc(dateText).set({ status: status });
+    const writeResult = await admin.firestore().collection("status").doc("status").set({ status: req0 });
     console.log("status: " + status);
     res.send(status);
   }

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -77,13 +77,13 @@ body {
 }
 #status-title {
   flex-wrap: nowrap;
-  font-size: 3.5vw;
+  font-size: 3.2vw;
   display: inline;
   margin-right: 0.5vw;
 }
 #status-text {
   flex-wrap: nowrap;
-  font-size: 3.5vw;
+  font-size: 3.2vw;
   display: inline;
   white-space: nowrap;
   margin-left: 0.5vw;

--- a/public/index.html
+++ b/public/index.html
@@ -35,7 +35,19 @@
 	<script src="https://www.gstatic.com/firebasejs/7.17.1/firebase-analytics.js"></script>
 
 	<!-- Initialize Firebase -->
-	<!-- Firebase config and API key omitted -->
+	<script>
+		const firebaseConfig = {
+			apiKey: "AIzaSyBlGbkUa9N5hd9iqGPA0nrOvRW4h0O5uBc",
+			authDomain: "mpls-winter-parking.firebaseapp.com",
+			databaseURL: "https://mpls-winter-parking.firebaseio.com",
+			projectId: "mpls-winter-parking",
+			storageBucket: "mpls-winter-parking.appspot.com",
+			messagingSenderId: "1001002629605",
+			appId: "1:1001002629605:web:14c6b7f28ca972f5eb170c",
+			measurementId: "G-KVKJBBEW20"
+		};
+		firebase.initializeApp(firebaseConfig);
+	</script>
 </head>
 
 <body>
@@ -62,10 +74,7 @@
 	</div>
   <a href="http://www.ci.minneapolis.mn.us/snow/snow_parking-info" target='blank'>Official Minneapolis Rules</a>
 	<a href="https://forms.gle/V4PDV2NjP8LwEeU47" target='blank'>Feedback</a>
-	<details>
-		<summary>About this app</summary>
-		<span>This web application was built as an alternative to the city's official snow emergency parking app. It uses the same dataset and is acquired from <a href="https://opendata.minneapolismn.gov/datasets/snow-emergency-routes" target="blank">the Minneapolis public data portal.</a> It also checks the snow emergency status every 5 minutes during snow emergency season.</span>
-		<span>Created by: <a href="https://bgoblirsch.github.io" target='blank'>Brandon Goblirsch</a></span>
+	<a href="https://github.com/bgoblirsch/mpls-winter-parking" target="blank">About</a>
 </div>
 
 <!-- DAY SELECTORS -->

--- a/public/map.js
+++ b/public/map.js
@@ -100,9 +100,9 @@ var routeData = {
   "type": "fill",
   "source": {
     type: 'vector',
-    url: 'mapbox://bgoblirsch.3o2enpx8'
+    url: 'mapbox://bgoblirsch.routes2020'
   },
-  "source-layer": "Snow_Emergency_Routes-74gvfg",
+  "source-layer": "routes2020",
 };
 
 map.on('load', function () {
@@ -211,16 +211,19 @@ function getStatus() {
   let statusCode;
 
   // try looking up the date string in the firestore db;
-  let docRef = db.collection("status").doc(date);
+  let docRef = db.collection("status").doc("status");
   docRef.get().then(function(doc) {
     if (doc.exists) {
       console.log(doc.data().status);
-      if (doc.data().status == "There is currently no snow emergency.") {
+      if (doc.data().status == "0") {
         // call setStatus() with 0 if db says no emergency
         setStatus(0);
-      } else {
-        // call setStatus() with 1 if db says anything other than no emergency
+      } else if (doc.data().status == "1") {
         setStatus(1);
+      } else if (doc.data().status == "2") {
+        setStatus(2);
+      } else if (doc.data().status == "3") {
+        setStatus(3);
       }
     } else {
       statusCode = -1;

--- a/tileset-recipe.json
+++ b/tileset-recipe.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "layers": {
+    "routes2020": {
+      "source": "mapbox://tileset-source/bgoblirsch/routes2020",
+      "minzoom": 10,
+      "maxzoom": 16
+    }
+  }
+}


### PR DESCRIPTION
- updated snow emergency routes to latest from Minneapolis data portal
- fixed the status info tooltip (status line overflowed to two lines on mobile for day 1 of emergencies)
- updated database logic - no longer dealing with historical dates, just reading a single "status" record in the db